### PR TITLE
Simplify build tags and allow static builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ to be widely applicable (and accepted by the upstream repo), then the fork
 becomes obsolete.
 
 The `master` branch reflects the upstream master.
-The `teleport` branch is the default and reflects the library version used by
-Teleport.
 
-There is no concept of semantic versioning for the `teleport` branch, it rolls
-forward as Teleport needs it to.
+The `teleport` branch is the default and reflects the library version used by
+Teleport. There is no concept of semantic versioning for the `teleport` branch,
+it rolls forward as Teleport needs it to.
+
+All builds are dynamic by default (Linux and macOS). You may use the
+`libfido2static` build tag to force static builds instead. The following
+libraries are required for static builds:
+
+* /usr/local/lib/libfido2.a
+* /usr/local/lib/libcbor.a
+* /usr/lib/x86_64-linux-gnu/libcrypto.a (Linux)
+* /usr/local/opt/openssl@1.1/lib/libcrypto.a (macOS)
+
+Other system libraries are linked dynamically (such as `libudev` and `libdl` on
+Linux).
 
 You are looking at the `teleport` branch now.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ libraries are required for static builds:
 * /usr/local/lib/libcbor.a
 * /usr/lib/x86_64-linux-gnu/libcrypto.a (Linux)
 * /usr/local/opt/openssl@1.1/lib/libcrypto.a (macOS)
+* /usr/local/lib/libudev.a (Linux,
+  [libeudev](https://github.com/eudev-project/eudev))
 
 Other system libraries are linked dynamically (such as `libudev` and `libdl` on
 Linux).

--- a/fido2.go
+++ b/fido2.go
@@ -10,7 +10,7 @@ package libfido2
 #cgo darwin,arm64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a
 
 #cgo linux,!libfido2static LDFLAGS: -lfido2
-#cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lpthread -ludev
+#cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/lib/libudev.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lpthread
 
 #include <fido.h>
 #include <fido/credman.h>

--- a/fido2.go
+++ b/fido2.go
@@ -6,7 +6,7 @@ package libfido2
 #cgo darwin,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/opt/openssl@1.1/lib/libcrypto.a
 
 #cgo linux,!libfido2static LDFLAGS: -lfido2
-#cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -ludev
+#cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lpthread -ludev
 
 #include <fido.h>
 #include <fido/credman.h>

--- a/fido2.go
+++ b/fido2.go
@@ -1,6 +1,13 @@
 package libfido2
 
 /*
+#cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include
+#cgo darwin,!libfido2static LDFLAGS: -lfido2
+#cgo darwin,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/opt/openssl@1.1/lib/libcrypto.a
+
+#cgo linux,!libfido2static LDFLAGS: -lfido2
+#cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -ludev
+
 #include <fido.h>
 #include <fido/credman.h>
 #include <stdlib.h>

--- a/fido2.go
+++ b/fido2.go
@@ -6,7 +6,7 @@ package libfido2
 #cgo darwin,amd64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/opt/openssl@1.1/lib/libcrypto.a
 
 #cgo darwin,arm64 CFLAGS: -I/opt/homebrew/opt/libfido2/include -I/opt/homebrew/opt/openssl@1.1/include
-#cgo darwin,arm64,!libfido2static LDFLAGS: /opt/homebrew/opt/libfido2/lib/libfido2.dylib
+#cgo darwin,arm64,!libfido2static LDFLAGS: -lfido2
 #cgo darwin,arm64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a
 
 #cgo linux,!libfido2static LDFLAGS: -lfido2

--- a/fido2.go
+++ b/fido2.go
@@ -1,9 +1,13 @@
 package libfido2
 
 /*
-#cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include
-#cgo darwin,!libfido2static LDFLAGS: -lfido2
-#cgo darwin,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/opt/openssl@1.1/lib/libcrypto.a
+#cgo darwin,amd64 CFLAGS: -I/usr/local/opt/openssl@1.1/include
+#cgo darwin,amd64,!libfido2static LDFLAGS: -lfido2
+#cgo darwin,amd64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/opt/openssl@1.1/lib/libcrypto.a
+
+#cgo darwin,arm64 CFLAGS: -I/opt/homebrew/opt/libfido2/include -I/opt/homebrew/opt/openssl@1.1/include
+#cgo darwin,arm64,!libfido2static LDFLAGS: /opt/homebrew/opt/libfido2/lib/libfido2.dylib
+#cgo darwin,arm64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a
 
 #cgo linux,!libfido2static LDFLAGS: -lfido2
 #cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lpthread -ludev

--- a/fido2_dynamic.go
+++ b/fido2_dynamic.go
@@ -1,9 +1,0 @@
-// +build dynamic
-
-package libfido2
-
-/*
-#cgo darwin LDFLAGS: -L/usr/local/lib -lfido2
-#cgo darwin CFLAGS: -I/usr/local/include -I/usr/local/opt/openssl/include
-*/
-import "C"

--- a/fido2_other.go
+++ b/fido2_other.go
@@ -1,9 +1,0 @@
-package libfido2
-
-/*
-#cgo linux LDFLAGS: -L/usr/lib/x86_64-linux-gnu -lfido2
-#cgo linux CFLAGS: -I/usr/include/fido
-#cgo windows LDFLAGS: -L${SRCDIR}/windows/lib -lfido2
-#cgo windows CFLAGS: -I${SRCDIR}/windows/include
-*/
-import "C"

--- a/fido2_static_amd64.go
+++ b/fido2_static_amd64.go
@@ -1,7 +1,0 @@
-package libfido2
-
-/*
-#cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/opt/openssl@1.1/lib/libcrypto.a ${SRCDIR}/darwin/amd64/lib/libcbor.a
-#cgo darwin CFLAGS: -I/usr/local/opt/libfido2/include -I/usr/local/opt/openssl@1.1/include
-*/
-import "C"

--- a/fido2_static_arm64.go
+++ b/fido2_static_arm64.go
@@ -1,7 +1,0 @@
-package libfido2
-
-/*
-#cgo darwin LDFLAGS: -framework CoreFoundation -framework IOKit /opt/homebrew/opt/libfido2/lib/libfido2.a /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a ${SRCDIR}/darwin/arm64/lib/libcbor.a
-#cgo darwin CFLAGS: -I/opt/homebrew/opt/libfido2/include -I/opt/homebrew/opt/openssl@1.1/include
-*/
-import "C"


### PR DESCRIPTION
There are two build modes for libfido2:

* Default/untagged: dynamic builds using `-lfido2`, with a few additions to make common systems easy to setup.
* `libfido2static`: static builds. Libraries are expected to be in exact locations, it's the user's responsibility to make them get there.

I've dropped windows builds, as last I tried it didn't work anyway. We'll fix that at a later time.

I've also dropped the various distinct files for tags/platforms, it seems simpler to have the tags together in a single place.