### PR TITLE
Use pkg-config to resolve libfido2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,11 @@ The `teleport` branch is the default and reflects the library version used by
 Teleport. There is no concept of semantic versioning for the `teleport` branch,
 it rolls forward as Teleport needs it to.
 
-All builds are dynamic by default (Linux and macOS). You may use the
-`libfido2static` build tag to force static builds instead. The following
-libraries are required for static builds:
-
-* /usr/local/lib/libfido2.a
-* /usr/local/lib/libcbor.a
-* /usr/lib/x86_64-linux-gnu/libcrypto.a (Linux)
-* /usr/local/opt/openssl@1.1/lib/libcrypto.a (macOS)
-* /usr/local/lib/libudev.a (Linux,
-  [libeudev](https://github.com/eudev-project/eudev))
-
-Other system libraries are linked dynamically (such as `libudev` and `libdl` on
-Linux).
+Builds are dynamic by default (Linux and macOS). You may use the
+`libfido2static` build tag to force static builds instead. Both rely on
+`pkg-config` (eg, `pkg-config --cflags --libs libfido2` must resolve correctly).
+Static builds refer to the `libfido2-static` library; users are expected to
+write their own definition for the libfido2-static.pc file in this case.
 
 You are looking at the `teleport` branch now.
 

--- a/fido2.go
+++ b/fido2.go
@@ -1,16 +1,8 @@
 package libfido2
 
 /*
-#cgo darwin,amd64 CFLAGS: -I/usr/local/opt/openssl@1.1/include
-#cgo darwin,amd64,!libfido2static LDFLAGS: -lfido2
-#cgo darwin,amd64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/opt/openssl@1.1/lib/libcrypto.a
-
-#cgo darwin,arm64 CFLAGS: -I/opt/homebrew/opt/libfido2/include -I/opt/homebrew/opt/openssl@1.1/include
-#cgo darwin,arm64,!libfido2static LDFLAGS: -lfido2
-#cgo darwin,arm64,libfido2static LDFLAGS: -framework CoreFoundation -framework IOKit /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /opt/homebrew/opt/openssl@1.1/lib/libcrypto.a
-
-#cgo linux,!libfido2static LDFLAGS: -lfido2
-#cgo linux,libfido2static LDFLAGS: /usr/local/lib/libfido2.a /usr/local/lib/libcbor.a /usr/local/lib/libudev.a /usr/lib/x86_64-linux-gnu/libcrypto.a -ldl -lpthread
+#cgo libfido2static pkg-config: libfido2-static
+#cgo !libfido2static pkg-config: libfido2
 
 #include <fido.h>
 #include <fido/credman.h>


### PR DESCRIPTION
A tad simpler than the previous scheme, plus we get some extra indirection, which comes in handy for multi-platform builds.